### PR TITLE
Pauze updates on midnight for Hamburg

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ This project makes it possible to collect data from municipalities about off-str
 | Country | City | Type | Update interval |
 |:--------|:-----|:-----|:----------------|
 | Netherlands | [Amsterdam](https://github.com/klaasnicolaas/python-garages-amsterdam) | Parking garages | Every 10 minutes |
-| Germany | [Hamburg](https://github.com/klaasnicolaas/python-hamburg) | Park and rides | Every 30 minutes |
+| Germany | [Hamburg](https://github.com/klaasnicolaas/python-hamburg) | Park and rides | Every 30 minutes (paused in midnight) |
 
 ## Development
 <details>

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,6 +36,7 @@ pyflakes==3.0.1
 pylint==2.16.1
 PyMySQL==1.0.2
 python-dotenv==0.21.1
+pytz==2022.7.1
 PyYAML==6.0
 ruamel.yaml==0.17.21
 ruamel.yaml.clib==0.2.7


### PR DESCRIPTION
By default, the API is often out between 00:00 and 01:00 CET. Which is why I now skip fetching the data in Docker from now on.